### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This code repository contains the source code of the custom container
 images maintenained by the Kiwix organisation (openZIM, Kiwix,
 OffSpot).
 
-For the orchestration, look at [https://github.com/kiwix/k8s](kiwix/k8s).
+For the orchestration, look at [https://github.com/kiwix/k8s].


### PR DESCRIPTION
Edited link so it points to https://github.com/kiwix/k8s instead of https://github.com/kiwix/container-images/blob/master/kiwix/k8s. The latter is 404.