### PR TITLE
Import Kiwix-build container images

### DIFF
--- a/.github/workflows/kiwix-build_ci.yml
+++ b/.github/workflows/kiwix-build_ci.yml
@@ -1,0 +1,44 @@
+name: Container images CD
+
+on:
+  push:
+    paths:
+      - 'kiwix-build_ci/**'
+
+env:
+  IMAGE_PREFIX: ghcr.io/kiwix/kiwix-build_ci_
+
+jobs:
+  Container:
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [f35, focal, bionic, alpine]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Get current date
+        run: echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+
+      - name: Retrieve the code
+        uses: actions/checkout@v3
+
+      - name: Setup container image name
+        id: env
+        run: |
+          echo "IMAGE_NAME=${{ env.IMAGE_PREFIX }}${{ matrix.variant }}" >> $GITHUB_OUTPUT
+
+      - name: Build container image
+        run: |
+          docker build -t ${{ steps.env.outputs.IMAGE_NAME }}:dev - < kiwix-build_ci/${{ matrix.variant }}_builder.dockerfile
+
+      - name: Tag release container image
+        if: github.event.ref == 'refs/heads/main'
+        run: |
+          docker tag ${{ steps.env.outputs.IMAGE_NAME }}:dev ${{ steps.env.outputs.IMAGE_NAME }}:${{ steps.date.outputs.DATE }}
+          docker tag ${{ steps.env.outputs.IMAGE_NAME }}:dev ${{ steps.env.outputs.IMAGE_NAME }}:latest
+
+      - name: Upload container image
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
+          docker push --all-tags ${{ steps.env.outputs.IMAGE_NAME }}

--- a/.github/workflows/kiwix-build_ci.yml
+++ b/.github/workflows/kiwix-build_ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'kiwix-build_ci/**'
+  workflow_dispatch:
 
 env:
   IMAGE_PREFIX: ghcr.io/kiwix/kiwix-build_ci_
@@ -18,7 +19,7 @@ jobs:
 
     steps:
       - name: Get current date
-        run: echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Retrieve the code
         uses: actions/checkout@v3
@@ -26,19 +27,21 @@ jobs:
       - name: Setup container image name
         id: env
         run: |
-          echo "IMAGE_NAME=${{ env.IMAGE_PREFIX }}${{ matrix.variant }}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${{ env.IMAGE_PREFIX }}${{ matrix.variant }}" >> $GITHUB_ENV
 
       - name: Build container image
         run: |
-          docker build -t ${{ steps.env.outputs.IMAGE_NAME }}:dev - < kiwix-build_ci/${{ matrix.variant }}_builder.dockerfile
+          docker build -t ${{ env.IMAGE_NAME }}:dev - < kiwix-build_ci/${{ matrix.variant }}_builder.dockerfile
 
-      - name: Tag release container image
-        if: github.event.ref == 'refs/heads/main'
-        run: |
-          docker tag ${{ steps.env.outputs.IMAGE_NAME }}:dev ${{ steps.env.outputs.IMAGE_NAME }}:${{ steps.date.outputs.DATE }}
-          docker tag ${{ steps.env.outputs.IMAGE_NAME }}:dev ${{ steps.env.outputs.IMAGE_NAME }}:latest
-
-      - name: Upload container image
+      - name: Upload container image to :dev
         run: |
           echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
-          docker push --all-tags ${{ steps.env.outputs.IMAGE_NAME }}
+          docker push ${{ env.IMAGE_NAME }}:dev
+
+      - name: Update production tags
+        if: github.event.ref == 'refs/heads/main'
+        run: |
+          docker tag ${{ env.IMAGE_NAME }}:dev ${{ env.IMAGE_NAME }}:${{ env.DATE }}
+          docker push ${{ env.IMAGE_NAME }}:${{ env.DATE }}
+          docker tag ${{ env.IMAGE_NAME }}:dev ${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/kiwix-build_ci.yml
+++ b/.github/workflows/kiwix-build_ci.yml
@@ -1,4 +1,4 @@
-name: Container images CD
+name: Kiwix-build container images
 
 on:
   push:

--- a/kiwix-build_ci/README.md
+++ b/kiwix-build_ci/README.md
@@ -1,0 +1,15 @@
+To run the `kiwix-build` command line tool for openZIM & Kiwix CI and
+CD, Kiwix Build requires prepared compilation environments for
+multiple GNU/Linux systems.
+
+These prepared environments include: compilers, binary toolchains and
+any third-party tool necessary to run the compilation toolchain. They
+don't contain pre-compiled library dependencies build by kiwix-build,
+(like Xapian, Libicu, Libmicrohttps, ...) but it contains dependencies
+installed with package manager.
+
+These container images are necessary and intended to be used by Kiwix
+itself in many of its CI. But they are free to download et can be
+reused, although they can break anytime, therefore at your won risk.
+You can find them on
+[here](https://github.com/orgs/kiwix/packages?tab=packages&q=kiwix-build).

--- a/kiwix-build_ci/alpine_builder.dockerfile
+++ b/kiwix-build_ci/alpine_builder.dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.16
+LABEL org.opencontainers.image.source https://github.com/kiwix/container-images
 
 ENV LANG C.UTF-8
 ENV OS_NAME alpine

--- a/kiwix-build_ci/alpine_builder.dockerfile
+++ b/kiwix-build_ci/alpine_builder.dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.16
+
+ENV LANG C.UTF-8
+ENV OS_NAME alpine
+
+RUN apk update -q \
+  && apk add -q --no-cache \
+# Base build tools
+        bash build-base git py3-pip \
+# Packaged dependencies
+        xz-dev \
+        zstd-dev \
+        xapian-core-dev \
+        icu-dev icu-data-full \
+        gtest-dev
+
+# Create user
+RUN addgroup --gid 121 runner
+RUN adduser -u 1001 -G runner -h /home/runner -D runner
+USER runner
+ENV PATH /home/runner/.local/bin:$PATH
+RUN pip3 install meson ninja ; \
+    ln -s /usr/bin/python3 /home/runner/.local/bin/python

--- a/kiwix-build_ci/bionic_builder.dockerfile
+++ b/kiwix-build_ci/bionic_builder.dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:bionic
+LABEL org.opencontainers.image.source https://github.com/kiwix/container-images
 
 ENV LANG C.UTF-8
 ENV OS_NAME bionic

--- a/kiwix-build_ci/bionic_builder.dockerfile
+++ b/kiwix-build_ci/bionic_builder.dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:bionic
+
+ENV LANG C.UTF-8
+ENV OS_NAME bionic
+
+RUN apt update -q \
+  && apt-get update \
+  && apt install -q -y --no-install-recommends \
+# Base build tools
+    build-essential automake libtool cmake ccache pkg-config autopoint patch \
+    python3-pip python3-setuptools python3-wheel git subversion wget unzip \
+    ninja-build openssh-client curl \
+# Packaged dependencies
+    libbz2-dev uuid-dev zlib1g-dev \
+    libgtest-dev \
+# Other tools (to remove)
+#    vim less grep \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
+  && pip3 install meson pytest gcovr requests distro
+
+# Create user
+RUN groupadd --gid 121 runner
+RUN useradd --uid 1001 --gid 121 --create-home runner
+USER runner
+ENV PATH /home/runner/.local/bin:$PATH

--- a/kiwix-build_ci/f35_builder.dockerfile
+++ b/kiwix-build_ci/f35_builder.dockerfile
@@ -1,0 +1,28 @@
+FROM fedora:35
+
+ENV LANG C.UTF-8
+ENV OS_NAME f35
+
+RUN dnf install -y --nodocs \
+# Base build tools
+    make automake libtool cmake git-core subversion pkg-config gcc-c++ \
+    wget unzip ninja-build ccache which patch gcovr xz openssh-clients \
+    python3-pip \
+# Cross win32 compiler
+    mingw32-gcc-c++ mingw32-bzip2-static mingw32-win-iconv-static \
+    mingw32-winpthreads-static mingw32-zlib-static mingw32-xz-libs-static \
+    mingw32-libmicrohttpd \
+# python3
+    python3-pip python-unversioned-command \
+# Other tools (to remove)
+#    vim less grep
+  && dnf remove -y "*-doc" \
+  && dnf autoremove -y \
+  && dnf clean all \
+  && pip3 install meson pytest requests distro
+
+# Create user
+RUN groupadd --gid 121 runner
+RUN useradd --uid 1001 --gid 121 --create-home runner
+USER runner
+ENV PATH /home/runner/.local/bin:$PATH

--- a/kiwix-build_ci/f35_builder.dockerfile
+++ b/kiwix-build_ci/f35_builder.dockerfile
@@ -1,4 +1,5 @@
 FROM fedora:35
+LABEL org.opencontainers.image.source https://github.com/kiwix/container-images
 
 ENV LANG C.UTF-8
 ENV OS_NAME f35

--- a/kiwix-build_ci/focal_builder.dockerfile
+++ b/kiwix-build_ci/focal_builder.dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:focal
+
+ENV LANG C.UTF-8
+ENV OS_NAME focal
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update -q \
+  && apt install -q -y --no-install-recommends \
+# Base build tools
+    build-essential automake libtool cmake ccache pkg-config autopoint patch \
+    python3-pip python3-setuptools python3-wheel git subversion wget unzip \
+    ninja-build openssh-client curl libgl-dev \
+# Python (2) is needed to install android-ndk
+    python \
+# Packaged dependencies
+    libbz2-dev libmagic-dev uuid-dev zlib1g-dev \
+    libmicrohttpd-dev aria2 libgtest-dev libgl-dev \
+# Devel package to compile python modules
+    libxml2-dev libxslt-dev python3-dev \
+# Qt packages
+    libqt5gui5 qtbase5-dev qtwebengine5-dev libqt5svg5-dev qt5-image-formats-plugins qt5-default \
+# To create the appimage of kiwix-desktop
+    libfuse2 fuse patchelf \
+# Flatpak tools
+    elfutils flatpak flatpak-builder \
+# Cross win32 compiler
+    g++-mingw-w64-i686 gcc-mingw-w64-i686 gcc-mingw-w64-base mingw-w64-tools \
+# Cross compile i586
+    libc6-dev-i386 lib32stdc++6 gcc-multilib g++-multilib \
+# Other tools (to remove)
+#    vim less grep \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
+  && pip3 install meson pytest gcovr requests distro
+
+# Create user
+RUN groupadd --gid 121 runner
+RUN useradd --uid 1001 --gid 121 --create-home runner
+USER runner
+ENV PATH /home/runner/.local/bin:$PATH

--- a/kiwix-build_ci/focal_builder.dockerfile
+++ b/kiwix-build_ci/focal_builder.dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:focal
+LABEL org.opencontainers.image.source https://github.com/kiwix/container-images
 
 ENV LANG C.UTF-8
 ENV OS_NAME focal


### PR DESCRIPTION
openZIM and Kiwix CI/CD kiwix-build usage relies on container images with ready-to-use compilation environments.

These container images have been prepared within the kiwix-build repository so far, but this had a few inconveniences:
* Kiwix-build doing already many things, this was not simplifying the situation (see https://github.com/kiwix/kiwix-build/wiki/Kiwix-Build-usage-in-CI-&-CD).
* It's not the primary role anyway of Kiwix-build repository to prepare its runtime environment in the special use case of our CI/CD
* We have a dedicated repository for creating our container images and it's here

The only thing which has changed from the user point-of-view is that instead of making a Github release to generate a new release of the images, each time we merge to `main`, then a new tag with the current date is generated. `dev` versions continue to be made to each push (whatever on `main` or feature branch).

Once merged, we should reassigne the packages to this repository (in place of `kiwix/kiwix-build`). 