### PR TITLE
Changing mirrorbrain's check_large_file threshold

### DIFF
--- a/mirrorbrain/Dockerfile
+++ b/mirrorbrain/Dockerfile
@@ -84,6 +84,12 @@ COPY ./sql/* mirrorbrain-$MB_VERSION/sql/
 #Install start script
 COPY bin/* /usr/local/bin/
 RUN chmod 0500 /usr/local/bin/*
+# Hack: change scanner variable $gig2 from 2GiB to 256GiB
+# this is used as a threshold on rsync scans
+# Files larger than it trigger a Range-Request HTTP download.
+# If the request fails a warning is printed
+# Those requests are not necessary and create load on mirrors
+RUN sed -i 's/gig2 = 1<<31;/gig2 = 1<<38; # HACKED --/' /usr/bin/scanner
 
 #Start !
 CMD ["start.sh"]


### PR DESCRIPTION
Mirrobrain scanner has a `$gig2` variable set at 2GiB It is used as a threshold on rsync scans
Files larger than it trigger a Range-Request HTTP download. If the request fails a warning is printed

Those requests are not necessary and create load on mirrors

This changes this variable value to 256GiB