### PR TITLE
Update and pin Manylinux CI `FROM` image

### DIFF
--- a/kiwix-build_ci/manylinux_builder.dockerfile
+++ b/kiwix-build_ci/manylinux_builder.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64:2024.11.30-1
 LABEL org.opencontainers.image.source https://github.com/kiwix/container-images
 
 ENV LANG C.UTF-8
@@ -15,7 +15,7 @@ RUN dnf install -y --nodocs \
   && dnf clean all \
   && python3.12 -m pip install meson pytest requests distro
 
-ENV PATH /opt/_internal/cpython-3.12.3/bin:$PATH
+ENV PATH /opt/_internal/cpython-3.12.7/bin:$PATH
 
 # Create user
 RUN groupadd --gid 121 runner


### PR DESCRIPTION
This PR is an attempt to fix CI for https://github.com/kiwix/kiwix-build/pull/771

Because the `FROM` of the Manylinux was not pinned, latest rebuild has made our `anylinux_builder.dockerfile` obselete in a way which was only detectable later at run (bad `$ENV` variable).

This is exactly to avoid this kind of hassle that all dependencies should always be fixed/pinned!

I don't understand why we have all these tools installed outside the system paths, which then generate the need of a customized `$PATH`. But I have decided to be conservative and just keep this approach and fix things using the current approach.