### PR TITLE
Add support for installing script from any branch

### DIFF
--- a/maintenance/install_scripts.py
+++ b/maintenance/install_scripts.py
@@ -40,7 +40,7 @@ def expand_url(url):
     if uri.scheme == "github":
         path = pathlib.Path(uri.path[1:])
         repo = f"{uri.netloc}/{path.parts[0]}"
-        branch = get_main_branch(repo)
+        branch = dict(urllib.parse.parse_qsl(uri.query)).get("branch", get_main_branch(repo))
         return (
             f"https://raw.githubusercontent.com/{repo}/{branch}"
             f"/{'/'.join(path.parts[1:])}"


### PR DESCRIPTION
With this PR, `install_script.py` can install the script from any github branch, specified with a `?branch=xxx` query in URI.

E.g. if one want to install script in `kiwix/operations` repo on `test` branch at `zim/library-mgmt/library-maint.py`, the URI to use will be `github://kiwix/operations/zim/library-mgmt/library-maint.py?branch=test`

Useful mostly for testing scripts in a branch before merging a PR (or even before submitting the PR, depending on the difficulty).