### PR TITLE
Added libqt6opengl6-dev to jammy builder

### DIFF
--- a/kiwix-build_ci/jammy_builder.dockerfile
+++ b/kiwix-build_ci/jammy_builder.dockerfile
@@ -19,7 +19,7 @@ RUN apt update -q \
 # Qt5 packages
     libqt5gui5 qtbase5-dev qtwebengine5-dev libqt5svg5-dev qt5-image-formats-plugins \
 # Qt6 packages
-    qt6-base-dev qt6-base-dev-tools qt6-webengine-dev libqt6webenginecore6-bin libqt6svg6 \
+    qt6-base-dev qt6-base-dev-tools qt6-webengine-dev libqt6opengl6-dev libqt6webenginecore6-bin libqt6svg6 \
 # To create the appimage of kiwix-desktop
     libfuse2 fuse patchelf \
 # Flatpak tools


### PR DESCRIPTION
Under jammy, `libqt6opengl6-dev` is not a dependency of `qt6-base-dev` but merely a recommended package, however that package is required for building GUI applications. In particular, without that package `kiwix-build` CI [fails to build `kiwix-desktop`](https://github.com/kiwix/kiwix-build/actions/runs/15486684463/job/43602867273?pr=799) with the following error:

```
build kiwix-desktop (native_dyn):
Stopping build due to errors
  configure kiwix-desktop : ERROR
run command '['qmake', 'PREFIX=/home/runner/BUILD_linux-x86_64/INSTALL', '/home/runner/SOURCE/kiwix-desktop']'
current directory is '/home/runner/BUILD_linux-x86_64/kiwix-desktop'
env is :
  GITHUB_WORKSPACE : '/__w/kiwix-build/kiwix-build'
  HOSTNAME : 'b55d95974a75'
  GITHUB_PATH : '/__w/_temp/_runner_file_commands/add_path_9b9d63e5-557c-48c5-8179-7a5e83eed2d2'
  GITHUB_ACTION : '__run_6'
  GITHUB_RUN_NUMBER : '3691'
  RUNNER_NAME : 'GitHub Actions 33'
  GITHUB_REPOSITORY_OWNER_ID : '826219'
  COMPILE_CONFIG : 'native_dyn'
  GITHUB_TRIGGERING_ACTOR : 'kelson42'
  GITHUB_REF_TYPE : 'branch'
  PWD : '/home/runner'
  SSH_KEY : '/tmp/id_rsa'
  GITHUB_REPOSITORY_ID : '77994264'
  GITHUB_ACTIONS : 'true'
  GITHUB_SHA : '79fd7cbb3177b1374cac649b93b60fa0a6b5653d'
  GITHUB_WORKFLOW_REF : 'kiwix/kiwix-build/.github/workflows/ci.yml@refs/heads/base-deps-qt6'
  RUNNER_ENVIRONMENT : 'github-hosted'
  GITHUB_REF : 'refs/heads/base-deps-qt6'
  RUNNER_OS : 'Linux'
  GITHUB_REF_PROTECTED : 'false'
  HOME : '/home/runner'
  GITHUB_API_URL : 'https://api.github.com/'
  LANG : 'C.UTF-8'
  RUNNER_ARCH : 'X64'
  RUNNER_TEMP : '/__w/_temp'
  GITHUB_STATE : '/__w/_temp/_runner_file_commands/save_state_9b9d63e5-557c-48c5-8179-7a5e83eed2d2'
  GITHUB_ENV : '/__w/_temp/_runner_file_commands/set_env_9b9d63e5-557c-48c5-8179-7a5e83eed2d2'
  GITHUB_EVENT_PATH : '/github/workflow/event.json'
  GITHUB_EVENT_NAME : 'push'
  GITHUB_RUN_ID : '15486684463'
  GITHUB_STEP_SUMMARY : '/__w/_temp/_runner_file_commands/step_summary_9b9d63e5-557c-48c5-8179-7a5e83eed2d2'
  GITHUB_ACTOR : 'kelson42'
  GITHUB_RUN_ATTEMPT : '1'
  GITHUB_GRAPHQL_URL : 'https://api.github.com/graphql'
  GITHUB_SERVER_URL : 'https://github.com/'
  SHLVL : '1'
  GITHUB_ACTOR_ID : '1029718'
  RUNNER_TOOL_CACHE : '/__t'
  GITHUB_WORKFLOW_SHA : '79fd7cbb3177b1374cac649b93b60fa0a6b5653d'
  GITHUB_REF_NAME : 'base-deps-qt6'
  GITHUB_JOB : 'Linux'
  GITHUB_REPOSITORY : 'kiwix/kiwix-build'
  GITHUB_RETENTION_DAYS : '90'
  RUNNER_WORKSPACE : '/__w/kiwix-build'
  GITHUB_ACTION_REPOSITORY : ''
  OS_NAME : 'jammy'
  PATH : '/home/runner/BUILD_linux-x86_64/INSTALL/bin:/home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
  GITHUB_BASE_REF : ''
  CI : 'true'
  GITHUB_REPOSITORY_OWNER : 'kiwix'
  GITHUB_HEAD_REF : ''
  GITHUB_ACTION_REF : ''
  GITHUB_WORKFLOW : 'CI'
  QT_SELECT : 'qt6'
  DEBIAN_FRONTEND : 'noninteractive'
  GITHUB_OUTPUT : '/__w/_temp/_runner_file_commands/set_output_9b9d63e5-557c-48c5-8179-7a5e83eed2d2'
  OLDPWD : '/__w/kiwix-build/kiwix-build'
  _ : 'kiwix-build/.github/scripts/build_projects.py'
  SKIP_BIG_MEMORY_TEST : '1'
  PKG_CONFIG_PATH : '/home/runner/BUILD_linux-x86_64/INSTALL/lib/x86_64-linux-gnu/pkgconfig'
  LD_LIBRARY_PATH : '/home/runner/BUILD_linux-x86_64/INSTALL/lib:/home/runner/BUILD_linux-x86_64/INSTALL/lib/x86_64-linux-gnu'
  QMAKE_CXXFLAGS : '-I/home/runner/BUILD_linux-x86_64/INSTALL/include '
  CPPFLAGS : '-I/home/runner/BUILD_linux-x86_64/INSTALL/include '
  QMAKE_LFLAGS : '-L/home/runner/BUILD_linux-x86_64/INSTALL/lib -L/home/runner/BUILD_linux-x86_64/INSTALL/lib/x86_64-linux-gnu '
  LDFLAGS : '-L/home/runner/BUILD_linux-x86_64/INSTALL/lib -L/home/runner/BUILD_linux-x86_64/INSTALL/lib/x86_64-linux-gnu '
Info: creating stash file /home/runner/BUILD_linux-x86_64/kiwix-desktop/.qmake.stash
Project ERROR: Unknown module(s) in QT: opengl
```