### PR TITLE
Forced meson to v1.6.1 in builder images

### DIFF
--- a/kiwix-build_ci/alpine_builder.dockerfile
+++ b/kiwix-build_ci/alpine_builder.dockerfile
@@ -20,5 +20,5 @@ RUN addgroup --gid 121 runner
 RUN adduser -u 1001 -G runner -h /home/runner -D runner
 USER runner
 ENV PATH /home/runner/.local/bin:$PATH
-RUN pip3 install meson ninja ; \
+RUN pip3 install meson==1.6.1 ninja ; \
     ln -s /usr/bin/python3 /home/runner/.local/bin/python

--- a/kiwix-build_ci/f35_builder.dockerfile
+++ b/kiwix-build_ci/f35_builder.dockerfile
@@ -20,7 +20,7 @@ RUN dnf install -y --nodocs \
   && dnf remove -y "*-doc" \
   && dnf autoremove -y \
   && dnf clean all \
-  && pip3 install meson pytest requests distro
+  && pip3 install meson==1.6.1 pytest requests distro
 
 # Create user
 RUN groupadd --gid 121 runner

--- a/kiwix-build_ci/focal_builder.dockerfile
+++ b/kiwix-build_ci/focal_builder.dockerfile
@@ -32,7 +32,7 @@ RUN apt update -q \
 #    vim less grep \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
-  && pip3 install meson pytest gcovr requests distro
+  && pip3 install meson==1.6.1 pytest gcovr requests distro
 
 # Create user
 RUN groupadd --gid 121 runner

--- a/kiwix-build_ci/jammy_builder.dockerfile
+++ b/kiwix-build_ci/jammy_builder.dockerfile
@@ -32,7 +32,7 @@ RUN apt update -q \
 #    vim less grep \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
-  && pip3 install meson pytest gcovr requests distro
+  && pip3 install meson==1.6.1 pytest gcovr requests distro
 
 # Set Qt6 per default (QT_SELECT has to be set to Qt5 so Kiwix Linux/Windows compiles)
 RUN qtchooser -install qt6 $(which qmake6)

--- a/kiwix-build_ci/manylinux_builder.dockerfile
+++ b/kiwix-build_ci/manylinux_builder.dockerfile
@@ -13,7 +13,7 @@ RUN dnf install -y --nodocs \
   && dnf remove -y "*-doc" \
   && dnf autoremove -y \
   && dnf clean all \
-  && python3.12 -m pip install meson pytest requests distro
+  && python3.12 -m pip install meson==1.6.1 pytest requests distro
 
 ENV PATH /opt/_internal/cpython-3.12.7/bin:$PATH
 

--- a/kiwix-build_ci/noble_builder.dockerfile
+++ b/kiwix-build_ci/noble_builder.dockerfile
@@ -30,7 +30,7 @@ RUN apt update -q \
     libc6-dev-i386 lib32stdc++6 gcc-multilib g++-multilib \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
-  && pip3 install meson pytest gcovr requests distro --break-system-packages \
+  && pip3 install meson==1.6.1 pytest gcovr requests distro --break-system-packages \
   && qtchooser -install qt6 $(which qmake6)
 
 # Create user

--- a/kiwix-build_ci/oracular_builder.dockerfile
+++ b/kiwix-build_ci/oracular_builder.dockerfile
@@ -30,7 +30,7 @@ RUN apt update -q \
     libc6-dev-i386 lib32stdc++6 gcc-multilib g++-multilib \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
-  && pip3 install meson pytest gcovr requests distro --break-system-packages \
+  && pip3 install meson==1.6.1 pytest gcovr requests distro --break-system-packages \
   && qtchooser -install qt6 $(which qmake6)
 
 # Create user


### PR DESCRIPTION
In builder images released on 2025-06-06 meson was upgraded to version 1.8.1 compared to version 1.6.1 found in the previous release on 2025-01-05. That change resulted in certain failures in kiwix-build CI. Hence this PR.